### PR TITLE
Roads with no ref

### DIFF
--- a/input-data/parameters.csv
+++ b/input-data/parameters.csv
@@ -1,6 +1,6 @@
 name,min_cycling_potential,min_grouped_cycling_potential,min_grouped_length,city_centre_buffer_radius,key_destination_buffer_radius,regexclude
 Birmingham,0,100,500,8000,5000,"qwerty"
-Bristol,0,100,500,8000,5000,"qwerty"
+Bristol,0,50,400,8000,5000,"qwerty"
 Cambridge,0,100,100,8000,5000,"hills"
 Leeds,0,100,500,8000,5000,"wellington"
 Leicester,0,100,500,8000,5000,"qwerty"


### PR DESCRIPTION
I've added code to include roads with no ref (this is sometimes missing even for A roads). I've excluded roads with no ref from the 'top_n' list. 

I've also altered various parameters:
- width >= 10
- min_grouped_cycling_potential = 50 (this was not specified at all before, so we had groups with very low mean cycling potential being shown on the maps)
- min_grouped_length = 400

For roads selected as a 'top route' and highlighted in grey, we should show every segment that matches the basic criteria of width/number of lanes and cycling potential. This will better show the parts of Gloucester Road that are now being excluded, because various sections >=10m width fall foul of the min_grouped_length criteria during grouping.