### PR TITLE
Filters, grouping and roads with no ref

### DIFF
--- a/code/stphil.R
+++ b/code/stphil.R
@@ -1,0 +1,3 @@
+r_positive[which(r_positive$ref == "A4320" & r_positive$lanes_f == 1),] = r_positive[which(r_positive$ref == "A4320" & r_positive$lanes_f == 1),] %>%
+  mutate(lanes_f = 2, lanesforward = 2)
+


### PR DESCRIPTION
This improves how we group segments and filter by cycle potential and group length. The rules for roads with no ref are slightly stricter than the rest, to avoid including rogue segments from side streets or very short roads.