### PR TITLE
Make better use of the groups we already have

### DIFF
--- a/code/build.R
+++ b/code/build.R
@@ -332,6 +332,8 @@ r_lanes = rbind(rg_new2, r_linestrings_without_ref2)
 # mapview::mapview(r_lanes)
 
 
+# Remove segments not part of a wider group (500m+) -----------------------
+
 rg_buff = geo_buffer(shp = r_lanes, dist = buff_dist_large)
 touching_list = st_intersects(rg_buff)
 g = igraph::graph.adjlist(touching_list)
@@ -346,6 +348,19 @@ rg_new3 = r_lanes %>%
   ungroup()
 
 # mapview::mapview(rg_new3)
+
+
+# Split long roads (with or without ref) into suitable sections -----------
+
+# Select roads with group2_length > 2km
+
+# Incrementally split into named sections (longest first) if each named section is > min_grouped_length (500m) and/or contiguous using buff_dist_large (100m). Identify which named sections touch one another (20m buffer) and use this to arrange the groups.
+
+# If that's not possible, split using 50m buffer, if each section is > min_grouped_length (500m). Or identify the longest gap within the group
+
+# If that's not possible, split at midpoint(s), or use cycling potential
+
+
 # create a new group to capture long continuous sections with the same name
 min_length_named_road = 1000
 rg_new4 = rg_new3 %>% 
@@ -359,6 +374,8 @@ rg_new4 = rg_new3 %>%
 # Only one group (meaning no impact on results) in many regions:
 table(rg_new4$long_named_section)
 
+
+# Name the groups and calculate stats -------------------------------------
 
 
 # find group membership of top named roads

--- a/code/build.R
+++ b/code/build.R
@@ -473,10 +473,12 @@ if(nrow(spare_lanes) == 0) {
 }
 # show wide segments not groups:
 # width_10m = r_lanes_final %>% filter(Status == labels[1])
-wide_lane_groups = r_lanes_final %>% filter(Status == labels[3])
+wide_lane_groups = r_lanes_final %>% 
+  filter(`Estimated width` != "<10 m") %>%
+  filter(Status != labels[1])
 wide_lane_segments = rg_new4[wide_lane_groups, , op = sf::st_within]
 wide_lanes = wide_lane_segments %>%
-  # filter(width >= 10 & !idGlobal %in% spare_lanes$idGlobal) %>% 
+  filter(!idGlobal %in% spare_lanes$idGlobal) %>% 
   filter(width >= 10) %>% 
   mutate(Status = labels[3])
 # edge case: there are no wide lanes

--- a/code/build.R
+++ b/code/build.R
@@ -441,7 +441,7 @@ r_lanes_final = r_lanes_joined %>%
     Status = case_when(
       group_id %in% r_lanes_top$group_id ~ labels[1],
       majority_spare_lane ~ labels[2],
-      mean_width >= 10 ~ labels[3]
+      mean_width >= 10 & ! majority_spare_lane ~ labels[3]
     ),
     `Estimated width` = case_when(
       mean_width < 10 ~ "<10 m",
@@ -476,7 +476,8 @@ if(nrow(spare_lanes) == 0) {
 wide_lane_groups = r_lanes_final %>% filter(Status == labels[3])
 wide_lane_segments = rg_new4[wide_lane_groups, , op = sf::st_within]
 wide_lanes = wide_lane_segments %>%
-  filter(width >= 10 & !idGlobal %in% spare_lanes$idGlobal) %>% 
+  # filter(width >= 10 & !idGlobal %in% spare_lanes$idGlobal) %>% 
+  filter(width >= 10) %>% 
   mutate(Status = labels[3])
 # edge case: there are no wide lanes
 if(nrow(wide_lanes) == 0) {

--- a/code/build.R
+++ b/code/build.R
@@ -379,7 +379,9 @@ r_lanes_grouped2 = rg_new4 %>%
       TRUE ~ case_when(
         names(table(ref))[which.max(table(ref))] != "" ~
           names(table(ref))[which.max(table(ref))],
-        TRUE ~ "Unnamed road")
+        TRUE ~ case_when(
+          names(desc(table(ref)))[2] != "NA" ~ paste("(",names(desc(table(ref)))[2],")"),
+          TRUE ~ "Unnamed road"))
       ), 
     group_length = round(sum(length)),
     mean_cycling_potential = round(weighted.mean(cycling_potential, length, na.rm = TRUE)),

--- a/code/build.R
+++ b/code/build.R
@@ -359,7 +359,10 @@ rg_new3 = r_lanes %>%
 # If that's not possible, split using 50m buffer, if each section is > min_grouped_length (500m). Or identify the longest gap within the group
 
 # If that's not possible, split at midpoint(s), or use cycling potential
+short_roads = rg_new3 %>%
+  filter(group2_length <= 2000)
 
+rg_new4 = rbind()
 
 # create a new group to capture long continuous sections with the same name
 min_length_named_road = 1000

--- a/code/build.R
+++ b/code/build.R
@@ -479,7 +479,7 @@ wide_lane_groups = r_lanes_final %>%
 wide_lane_segments = rg_new4[wide_lane_groups, , op = sf::st_within]
 wide_lanes = wide_lane_segments %>%
   filter(!idGlobal %in% spare_lanes$idGlobal) %>% 
-  filter(width >= 10) %>% 
+  filter(width >= 10 | spare_lane == TRUE) %>% 
   mutate(Status = labels[3])
 # edge case: there are no wide lanes
 if(nrow(wide_lanes) == 0) {

--- a/code/chelt.R
+++ b/code/chelt.R
@@ -1,0 +1,115 @@
+# chelt = rg_new4[rg_new4$il == 3 & rg_new4$group == 120 & rg_new4$ref == "A38",]
+# 
+# chelt = rg_new3[rg_new3$group2 == "3 120 A38",]
+# mapview(chelt)
+# View(chelt)
+# 
+# length(unique(rg_new3$group2))
+# long = rg_new3[rg_new3$group2_length > 2000,]
+# length(unique(long$group2))
+# mapview(long)
+
+# Split long roads (with or without ref) into suitable sections -----------
+
+# Select roads with group2_length > 2km
+long_roads = rg_new3 %>%
+  filter(group2_length > 2000)
+
+# Split into sections by road name, and split these into contiguous sections using buff_dist_large (100m).
+lgs = unique(long_roads$name)
+
+i = "Cheltenham Road"
+
+# create per name groups
+long_list = lapply(lgs, FUN = function(i) {
+  lg = long_roads %>% filter(name == i)
+  # mapview::mapview(lg)
+  l_buff = lg %>%
+    st_transform(27700) %>%
+    st_buffer(buff_dist_large) %>%
+    st_transform(4326)
+  touching_list = st_intersects(l_buff)
+  g = igraph::graph.adjlist(touching_list)
+  components = igraph::components(g)
+  lg$il = components$membership
+  lg
+})
+
+lg_new = do.call(rbind, long_list)
+
+#Create group IDs for each section
+lg_new$group3 = paste(lg_new$name, lg_new$group2, lg_new$il) # Each record now has unique group3
+lg_new$il = NULL
+
+# Calculate length and aggregate
+lg_new2 = lg_new %>% 
+  group_by(group2, group3) %>%
+  mutate(
+    group3_length = sum(length)
+  ) %>%
+  summarise(group3_length = mean(group3_length)) %>%
+  st_transform(27700)
+
+# Find the centroid of each section
+lg_c = sf::st_centroid(lg_new2)
+
+
+# why are West Street group2 vanishing? "4 120 A38" all joined groups seem to be disappearing see mapview(lg_new2)
+
+# If the shortest section is < min_grouped_length (500m), join it together with the section with the closest centroid. Recalculate the length and centroid of this new section. 
+# Keep going until all sections are >500m (since this is the minimum length required for top routes) 
+
+while (min(lg_c$group3_length) < min_grouped_length) {
+  shortest = NULL
+  nearest = NULL
+  near = NULL
+  mindist = NULL
+  shortest_l = NULL
+  nearest_l = NULL
+  new_l = NULL
+  new_geom = NULL
+  new_joined = NULL
+  new_c = NULL
+  
+  shortest = lg_c[which(lg_c$group3_length == min(lg_c$group3_length)),]
+  if(dim(shortest)[1] > 1) shortest = shortest[1,]
+  near = lg_c %>% 
+    filter(group2 == shortest$group2) %>% 
+    filter(group3 != shortest$group3) # must remove the point itself from this group
+  
+  distances = NULL
+  for(i in 1:dim(near)[1]) {
+    distance = sf::st_distance(near[i,], shortest) # switch to projected
+    distances = c(distances, distance)
+  }
+  
+  mindist = which(distances == min(distances))
+  if(length(mindist) > 1) mindist = mindist[1]
+  nearest = near[mindist,]
+  
+  shortest_l = lg_new2[which(lg_new2$group3 == shortest$group3),]
+  nearest_l = lg_new2[which(lg_new2$group3 == nearest$group3),]
+  
+  new_l = rbind(shortest_l, nearest_l)
+  new_l$group3_length = round(sum(new_l$group3_length)) # this is still 2 rows long, should be one row
+  new_geom = sf::st_union(shortest_l, nearest_l) # switch to projected
+  new_joined = new_l[2,] %>% mutate(geometry = new_geom$geometry)
+
+  new_c = sf::st_centroid(new_joined)
+  
+  lg_new2 = lg_new2 %>%
+    filter(group3 != shortest$group3, group3 != nearest$group3) %>%
+    rbind(new_joined)
+  lg_c = lg_c %>%
+    filter(group3 != shortest$group3, group3 != nearest$group3) %>%
+    rbind(new_c)
+}
+
+lg_new2
+lg_c
+
+lg_new2 = lg_new2 %>%
+  st_transform(4326)
+
+
+

--- a/code/index.Rmd
+++ b/code/index.Rmd
@@ -27,7 +27,7 @@ source("code/build.R")
 
 Not quality assured.
 
-Please provide feedback on these preliminary results on this [web form (estimated time to complete: 5 minites)](https://urldefense.proofpoint.com/v2/url?u=https-3A__forms.office.com_Pages_ResponsePage.aspx-3Fid-3DqO3qvR3IzkWGPlIypTW3y9orQ9urif9IgBaXiRS9eEpUM0JCTDRFTTEwSDRVMUs0VVhVWEdGRDA3RS4u&d=DwMCaQ&c=troKkvwivNn_CddsvWCHHPiPoFoTgTGIbXJULvYU158&r=DXeEYtdSYDBZN2DBwEgAHMmX5PQ_ob9r2MynFWta2mU&m=mkyUa3RIC9d5LSrHUqk_WdstQR1OQuTWyYLBecHFMm0&s=dD7GVcQbjZ2AcdCObSe-rNKmLLDBhu98ChFupIIrlJA&e=).
+Please provide feedback on these preliminary results on this [web form (estimated time to complete: 5 minutes)](https://urldefense.proofpoint.com/v2/url?u=https-3A__forms.office.com_Pages_ResponsePage.aspx-3Fid-3DqO3qvR3IzkWGPlIypTW3y9orQ9urif9IgBaXiRS9eEpUM0JCTDRFTTEwSDRVMUs0VVhVWEdGRDA3RS4u&d=DwMCaQ&c=troKkvwivNn_CddsvWCHHPiPoFoTgTGIbXJULvYU158&r=DXeEYtdSYDBZN2DBwEgAHMmX5PQ_ob9r2MynFWta2mU&m=mkyUa3RIC9d5LSrHUqk_WdstQR1OQuTWyYLBecHFMm0&s=dD7GVcQbjZ2AcdCObSe-rNKmLLDBhu98ChFupIIrlJA&e=).
 
 # Introduction
 
@@ -95,11 +95,11 @@ We used certain eligibility criteria for the top routes:
 - unnamed roads cannot be a top route 
 - routes less than 500m in length cannot be a top route
 
-## 3. Spare lane(s) (not shown be default)
+## 3. Spare lane(s) (not shown by default)
 
 These are routes that have more than one vehicle lane in either direction and have a cycling potential above the minimum threshold (which varies according to region as it needs to be higher in e.g. Greater London than in rural areas).
 
-## 4. Width >= 10m  
+## 4. Width >= 10m (not shown by default)
 
 These routes are at least 10m in width and have a cycling potential above the minimum threshold. 
 


### PR DESCRIPTION
I haven't entirely solved the problem yet, but I've got a long way towards it, simply by making better use of the groups of roads that we already created during the earlier stages of the process (e.g. in identifying roads with no ref). Now there should no longer be a big bunch of roads in Leeds all called Meanwood Road, and there should be very few called Unnamed Road.

I still need to split up long roads with a ref, that may or may not change names at times, into shorter more manageable sections.  