### PR TITLE
Make maps less bitty

### DIFF
--- a/code/build.R
+++ b/code/build.R
@@ -538,9 +538,12 @@ if(nrow(spare_lanes) == 0) {
 }
 # show wide segments not groups:
 # width_10m = r_lanes_final %>% filter(Status == labels[1])
-wide_lane_groups = r_lanes_final %>% filter(Status == labels[3])
+wide_lane_groups = r_lanes_final %>% 
+  filter(`Estimated width` != "<10 m") %>%
+  filter(Status != labels[1])
 wide_lane_segments = route_segments_final[wide_lane_groups, , op = sf::st_within]
 wide_lanes = wide_lane_segments %>%
+  filter(!idGlobal %in% spare_lanes$idGlobal) %>% 
   filter(width >= 10 & !idGlobal %in% spare_lanes$idGlobal) %>% 
   mutate(Status = labels[3])
 # edge case: there are no wide lanes

--- a/code/build.R
+++ b/code/build.R
@@ -49,13 +49,9 @@ if(!exists("s")) {
 if(!exists("region_name")) {
   region_name = "West Yorkshire"
 }
-if(region_name == "Nottingham") {
-  region = regions %>% filter(str_detect(string = Name, pattern = "Nott")) %>% 
-    st_geometry() %>% 
-    st_union()
-} else {
-  region = regions %>% filter(Name == region_name)
-}
+
+region = regions %>% filter(Name == region_name)
+
 if(as.numeric(sf::st_area(region)) < 3000000000) {
   region = stplanr::geo_buffer(region, dist = 1000)
 }

--- a/code/build.R
+++ b/code/build.R
@@ -11,14 +11,12 @@ if(!exists("s")) {
   message("Loading global parameters")  
   s = c(
     `Grey basemap` = "Esri.WorldGrayCanvas",
+    `OSM existing cycle provision (CyclOSM)` = "https://b.tile-cyclosm.openstreetmap.fr/cyclosm/{z}/{x}/{y}.png",
     `PCT commuting, Government Target` = "https://npttile.vs.mythic-beasts.com/commute/v2/govtarget/{z}/{x}/{y}.png",
     `PCT schools, Government Target` = "https://npttile.vs.mythic-beasts.com/school/v2/govtarget/{z}/{x}/{y}.png",
-    `PCT commuting, Ebikes, ` = "https://npttile.vs.mythic-beasts.com/commute/v2/ebike/{z}/{x}/{y}.png",
-    `PCT schools, Go Dutch, ` = "https://npttile.vs.mythic-beasts.com/school/v2/dutch/{z}/{x}/{y}.png",
-    `Existing cycleways and cycle lanes` = "https://b.tile-cyclosm.openstreetmap.fr/cyclosm/{z}/{x}/{y}.png",
     `Satellite image` = "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'"
   )
-  tms = c(FALSE, TRUE, TRUE, TRUE, TRUE, FALSE, FALSE)
+  tms = c(FALSE, FALSE, TRUE, TRUE, FALSE)
   # test basemap:
   tmap_mode("view")
   if(!exists("parameters")) {

--- a/code/index.Rmd
+++ b/code/index.Rmd
@@ -89,7 +89,7 @@ The three main layers are arranged in order of planning timescales:
 
 1. The **Existing cycleways** layer provides an approximation of where cycling infrastructure exists **currently** (based on OpenStreetMap data downloaded in May 2020) and is intended to help identify gaps in the network that could be filled with new interventions.
 2. The **Top ranked new cycleways** layer is the central result of the analysis, providing a list of roads that have high cycling potential, a minimum threshold length, and spare space according to our definition. These may be strong candidates for reallocation of road space **immediately or in the near future** to create new cycleways on strategic corridors under the Emergency Active Travel Fund.
-3. The **Cohesive network** layer is intended to show what a joined-up cycle network could look like if we were to consider new cycleways by either closing roads to motorised traffic or creating one-way systems. Composed of roads that have high cycling potential on some or all of their length, the layer is designed to guide **long term planning**, alongside pre-existing plans such LCWIPs [@departmentfortransport_cycling_2017], towards a continuous and coherent network.
+3. The **Cohesive network** layer is intended to show what a joined-up cycle network could look like if we were to consider using a wider range of interventions to design new cycleways, such as closing roads to motorised traffic or creating one-way systems. Composed of roads that have high cycling potential on some or all of their length, the layer is designed to guide **long term planning**, alongside pre-existing plans such LCWIPs [@departmentfortransport_cycling_2017], towards a continuous and coherent network.
 
 These main layers, and two other layers that informed the results but which are not shown by default, are described in detail below.
 
@@ -145,9 +145,12 @@ Like the Spare lane(s) layer, this layer is intended to highlight road sections 
 
 # Basemaps
 
-There are also seven basemaps to choose from. The default basemap is grey and provides an uncluttered view. We then have basemap options showing four different scenarios from the Propensity to Cycle Tool. This allows our results to be compared with cycling potentials across the road network. The scenarios available show cycling potential for Commuting and travel to Schools under the Government Target scenario.
-
-A further basemap option shows all existing cycleways, including on-road cycle lanes. Finally, a satellite image is also available as a basemap.
+There are also five basemaps to choose from. The default basemap is grey and provides an uncluttered view. 
+The second basemap option is a thematic map which shows all existing cycleways, including on-road cycle lanes. 
+We then have two basemap options showing cycling potential for travel to work and travel to school from the Propensity to Cycle Tool. 
+This allows our results to be compared with cycling potentials across the wider road network. 
+These both follow the Government Target scenario; this is the same scenario as is used to derive the map layers described above. 
+Finally, a satellite image is also available as a basemap.
 
 
 # Known issues and limitations


### PR DESCRIPTION
This is a repeat of a change I made in an earlier branch. It makes the maps less bitty. Currently, we are excluding segments in a group with majority spare lanes, where the segment doesn't have a spare lane but is still >10m wide. This adds these segments to the 'estimated width >10m' layer, making the routes on the map more continuous.